### PR TITLE
Implement handlers, update JWT cookie handling, del isManageChat and modify error response timestamp format

### DIFF
--- a/src/main/java/com/group/docorofile/controllers/v1/api/auth/AuthAPIController.java
+++ b/src/main/java/com/group/docorofile/controllers/v1/api/auth/AuthAPIController.java
@@ -37,12 +37,10 @@ public class AuthAPIController {
         CustomUserDetails userDetails = (CustomUserDetails) auth.getPrincipal();
         String token = jwtTokenUtil.generateToken(userDetails);
 
-        // Tạo cookie chứa JWT
         Cookie jwtCookie = new Cookie("JWT", token);
         jwtCookie.setHttpOnly(true); // Không cho phép truy cập từ JavaScript để giảm rủi ro XSS
         jwtCookie.setPath("/"); // Áp dụng cho toàn bộ ứng dụng
 
-        // Thêm cookie vào response
         response.addCookie(jwtCookie);
 
         SuccessResponse successResponse  = new SuccessResponse("Login successful", HttpStatus.OK.value(), token, LocalDateTime.now());
@@ -54,8 +52,8 @@ public class AuthAPIController {
         // Tạo cookie mới có tên "JWT" với giá trị rỗng và maxAge = 0 để xóa cookie khỏi trình duyệt
         Cookie jwtCookie = new Cookie("JWT", null);
         jwtCookie.setHttpOnly(true);
-        jwtCookie.setPath("/");      // Áp dụng cho toàn bộ ứng dụng
-        jwtCookie.setMaxAge(0);      // Set maxAge = 0 để xóa cookie
+        jwtCookie.setPath("/");
+        jwtCookie.setMaxAge(0);
 
         response.addCookie(jwtCookie);
 

--- a/src/main/java/com/group/docorofile/entities/ModeratorEntity.java
+++ b/src/main/java/com/group/docorofile/entities/ModeratorEntity.java
@@ -12,5 +12,4 @@ import lombok.experimental.SuperBuilder;
 @Table(name = "moderators")
 public class ModeratorEntity extends UserEntity {
     private boolean isReportManage;
-    private boolean isChatManage;
 }

--- a/src/main/java/com/group/docorofile/exceptions/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/group/docorofile/exceptions/CustomAccessDeniedHandler.java
@@ -1,0 +1,32 @@
+package com.group.docorofile.exceptions;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group.docorofile.response.ForbiddenError;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setContentType("application/json");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+        ForbiddenError errorResponse = new ForbiddenError("Forbidden access");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/group/docorofile/exceptions/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/group/docorofile/exceptions/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.group.docorofile.exceptions;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.group.docorofile.response.ForbiddenError;
+import com.group.docorofile.response.UnauthorizedError;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException, ServletException {
+        // Đặt header kiểu JSON
+        response.setContentType("application/json");
+        // Đặt status code 401
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+
+        UnauthorizedError errorResponse = new UnauthorizedError("Forbidden access");
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/group/docorofile/response/ErrorResponse.java
+++ b/src/main/java/com/group/docorofile/response/ErrorResponse.java
@@ -1,19 +1,22 @@
 package com.group.docorofile.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 
 @JsonIgnoreProperties({"suppressed", "localizedMessage", "stackTrace", "cause"})
 public class ErrorResponse extends RuntimeException {
     private final int statusCode;
     private final String message;
-    private final LocalDateTime timestamp;
+    private final String timestamp;
 
     public ErrorResponse(String message, int statusCode) {
         super(message);
         this.message = message;
         this.statusCode = statusCode;
-        this.timestamp = LocalDateTime.now();
+        // Format theo ISO-8601
+        this.timestamp = LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME);
     }
 
     public int getStatusCode() {
@@ -25,7 +28,7 @@ public class ErrorResponse extends RuntimeException {
         return message;
     }
 
-    public LocalDateTime getTimestamp() {
+    public String getTimestamp() {
         return timestamp;
     }
 }

--- a/src/main/java/com/group/docorofile/security/JwtTokenUtil.java
+++ b/src/main/java/com/group/docorofile/security/JwtTokenUtil.java
@@ -43,7 +43,6 @@ public class JwtTokenUtil {
         if(isModerator) {
             ModeratorEntity moderator = (ModeratorEntity) userDetails.getUser();
             builder.claim("isReportManage", moderator.isReportManage());
-            builder.claim("isChatManage", moderator.isChatManage());
         }
 
         return builder.signWith(KEY, SignatureAlgorithm.HS256).compact();

--- a/src/main/java/com/group/docorofile/security/SecurityConfig.java
+++ b/src/main/java/com/group/docorofile/security/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.group.docorofile.security;
 
 import com.group.docorofile.entities.UserEntity;
+import com.group.docorofile.exceptions.CustomAccessDeniedHandler;
+import com.group.docorofile.exceptions.CustomAuthenticationEntryPoint;
 import com.group.docorofile.models.users.CreateUserRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -22,6 +24,12 @@ public class SecurityConfig {
     @Autowired
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
+    @Autowired
+    private CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    @Autowired
+    private CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(csrf -> csrf.disable())
@@ -31,6 +39,9 @@ public class SecurityConfig {
                         .requestMatchers("/v1/api/users/new").permitAll()
                         .anyRequest().authenticated()
                 )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .accessDeniedHandler(customAccessDeniedHandler))
                 .logout(logout -> logout
                         .logoutUrl("/logout")
                         .logoutSuccessUrl("/login?logout")

--- a/src/main/java/com/group/docorofile/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/group/docorofile/services/impl/UserServiceImpl.java
@@ -51,7 +51,6 @@ public class UserServiceImpl implements iUserService {
                     .password(request.getPassword())
                     .isActive(true)
                     .isReportManage(request.getIsReportManage() != null ? request.getIsReportManage() : false)
-                    .isChatManage(request.getIsChatManage() != null ? request.getIsChatManage() : false)
                     .build();
         } else if ("MEMBER".equalsIgnoreCase(userType)) {
             user = MemberEntity.builder()
@@ -109,7 +108,6 @@ public class UserServiceImpl implements iUserService {
         if (user instanceof ModeratorEntity) {
             ModeratorEntity mod = (ModeratorEntity) user;
             mod.setReportManage(request.getIsReportManage() != null ? request.getIsReportManage() : mod.isReportManage());
-            mod.setChatManage(request.getIsChatManage() != null ? request.getIsChatManage() : mod.isChatManage());
         } else if (user instanceof MemberEntity) {
             MemberEntity member = (MemberEntity) user;
             member.setDownloadLimit(request.getDownloadLimit() != null ? request.getDownloadLimit() : member.getDownloadLimit());


### PR DESCRIPTION
This pull request includes several changes to enhance security handling, modify user entity attributes, and improve error response formatting. The most important changes are grouped into security enhancements, user entity modifications, and error response formatting improvements.

### Security Enhancements:

* Added `CustomAccessDeniedHandler` to handle access denied exceptions and return a JSON response with a 403 status code.
* Added `CustomAuthenticationEntryPoint` to handle authentication exceptions and return a JSON response with a 401 status code.
* Updated `SecurityConfig` to include the new custom handlers for access denied and authentication exceptions. [[1]](diffhunk://#diff-a898e40690c2fec300b2aabef361de1d52f4782ccca9069a66598467313022a6R4-R5) [[2]](diffhunk://#diff-a898e40690c2fec300b2aabef361de1d52f4782ccca9069a66598467313022a6R27-R32) [[3]](diffhunk://#diff-a898e40690c2fec300b2aabef361de1d52f4782ccca9069a66598467313022a6R42-R44)

### User Entity Modifications:

* Removed the `isChatManage` attribute from `ModeratorEntity` and related logic in `JwtTokenUtil` and `UserServiceImpl`. [[1]](diffhunk://#diff-7c63705bfde7ee030a9e7d6977519e3020c42da3cbdad36cfca864048e14016eL15) [[2]](diffhunk://#diff-b54acafc04d08a701ff4d8f4b69d9c5f6d38d92b9c0a4b2cae87d02e3c129e59L46) [[3]](diffhunk://#diff-86915f24715970260ba032f0c6957da1829eb19c461d99abbf638d79d9919fdcL54) [[4]](diffhunk://#diff-86915f24715970260ba032f0c6957da1829eb19c461d99abbf638d79d9919fdcL112)

### Error Response Formatting:

* Changed the `timestamp` field in `ErrorResponse` to be formatted as an ISO-8601 string instead of a `LocalDateTime` object. [[1]](diffhunk://#diff-4be8d29bac9eb7b03074aa72fc385a9768fbae5b23c9ad8d1f4eeade6d5b7758R3-R19) [[2]](diffhunk://#diff-4be8d29bac9eb7b03074aa72fc385a9768fbae5b23c9ad8d1f4eeade6d5b7758L28-R31)

### ✌️✅👉 [Auth & User CRUD Documentation](https://www.postman.com/docorona/workspace/docorofile/documentation/39571017-04ec1592-3830-47a2-950e-ddf02d58a999)