### PR TITLE
add @PreAuthorize

### DIFF
--- a/src/main/java/com/group/docorofile/controllers/v1/api/notification/NotificationController.java
+++ b/src/main/java/com/group/docorofile/controllers/v1/api/notification/NotificationController.java
@@ -9,6 +9,7 @@ import com.group.docorofile.services.impl.NotificationServiceImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
@@ -26,6 +27,7 @@ public class NotificationController {
         this.notificationService = notificationService;
     }
 
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR')")
     @PostMapping("/create")
     public ResponseEntity<SuccessResponse> createNotification(@RequestBody CreateNotificationRequest request) {
         NotificationDTO notification = notificationService.createNotification(
@@ -43,7 +45,7 @@ public class NotificationController {
 
         return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
-
+    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR', 'ROLE_MEMBER')")
     @GetMapping("")
     public ResponseEntity<ResultPaginationDTO> getAllNotifications(Pageable pageable) {
 
@@ -52,6 +54,7 @@ public class NotificationController {
         return ResponseEntity.ok().body(notificationService.fetchNotifications(email, pageable));
     }
 
+    @PreAuthorize("hasRole('ROLE_MEMBER')")
     @PatchMapping("/{id}/mark-as-read")
     public ResponseEntity<SuccessResponse> markAsRead(@PathVariable UUID id) {
         notificationService.markAsRead(id);


### PR DESCRIPTION
This pull request includes changes to the `NotificationController` to enhance security by adding role-based access control annotations. The most important changes include adding `@PreAuthorize` annotations to various methods to restrict access based on user roles.

Security enhancements:

* Added `@PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR')")` annotation to the `createNotification` method to restrict access to users with admin or moderator roles. (`src/main/java/com/group/docorofile/controllers/v1/api/notification/NotificationController.java`)
* Added `@PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR', 'ROLE_MEMBER')")` annotation to the `getAllNotifications` method to restrict access to users with admin, moderator, or member roles. (`src/main/java/com/group/docorofile/controllers/v1/api/notification/NotificationController.java`)
* Added `@PreAuthorize("hasRole('ROLE_MEMBER')")` annotation to the `markAsRead` method to restrict access to users with the member role. (`src/main/java/com/group/docorofile/controllers/v1/api/notification/NotificationController.java`)