### PR TITLE
feature(chat): handle profanity word in chat

### DIFF
--- a/src/main/java/com/group/docorofile/services/impl/MessageServiceImpl.java
+++ b/src/main/java/com/group/docorofile/services/impl/MessageServiceImpl.java
@@ -15,6 +15,7 @@ import com.group.docorofile.request.MessageRequest;
 import com.group.docorofile.response.MessageResponse;
 import com.group.docorofile.response.NotFoundError;
 import com.group.docorofile.services.iMessageService;
+import com.group.docorofile.utils.ProfanityFilter;
 import org.springframework.data.crossstore.ChangeSetPersister;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -50,10 +51,12 @@ public class MessageServiceImpl implements iMessageService {
         MemberEntity member = memberRepository.findById(senderId)
                 .orElseThrow(() -> new NotFoundError("Sender is not a member"));
 
+        String cleanMessage = ProfanityFilter.filterBadWords(request.getContent());
+
         MessageEntity message = MessageEntity.builder()
                 .chatRoom(chatRoom)
                 .sender(member)
-                .content(request.getContent())
+                .content(cleanMessage)
                 .build();
 
         messageRepository.save(message);

--- a/src/main/java/com/group/docorofile/utils/ProfanityFilter.java
+++ b/src/main/java/com/group/docorofile/utils/ProfanityFilter.java
@@ -1,0 +1,53 @@
+package com.group.docorofile.utils;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ProfanityFilter {
+    private static final Set<String> BAD_WORDS = new HashSet<>();
+
+    static {
+        try (BufferedReader reader = new BufferedReader(
+                new InputStreamReader(ProfanityFilter.class.getResourceAsStream("/badWords.txt")))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                BAD_WORDS.add(line.trim().toLowerCase());
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // Kiểm tra message có chứa từ cấm hoặc biến thể không
+    public static boolean containsBadWords(String message) {
+        String lowerMsg = message.toLowerCase();
+
+        for (String badWord : BAD_WORDS) {
+            String regex = String.join("[\\W_]*", badWord.split("")); // cho phép dấu đặc biệt giữa các chữ
+            regex = "(?i).*" + regex + ".*"; // không phân biệt hoa thường
+
+            if (lowerMsg.matches(regex)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // Thay từ cấm và biến thể bằng dấu *
+    public static String filterBadWords(String message) {
+        String filtered = message;
+
+        for (String badWord : BAD_WORDS) {
+            String regex = String.join("[\\W_]*", badWord.split(""));
+            regex = "(?i)" + regex;
+
+            String replacement = "*".repeat(badWord.length());
+            filtered = filtered.replaceAll(regex, replacement);
+        }
+        return filtered;
+    }
+}
+

--- a/src/main/resources/badWords.txt
+++ b/src/main/resources/badWords.txt
@@ -1,0 +1,26 @@
+địt
+đụ
+đm
+dm
+vcl
+vl
+cc
+vãi
+ccmm
+chửi
+óc chó
+đần
+dốt
+bố láo
+mẹ mày
+con mẹ mày
+fuck
+shit
+bitch
+đĩ
+cave
+lồn
+cặc
+buồi
+lồn
+cặc


### PR DESCRIPTION
This pull request introduces a profanity filter to sanitize messages before saving them to the database. The key changes include the addition of a utility class for filtering profane words and integrating this functionality into the message-sending service. A list of banned words is also added as a resource.

### Profanity Filtering Implementation:
* **Added `ProfanityFilter` utility class**: Implements methods to detect and replace profane words with asterisks. It reads a list of banned words from a resource file (`badWords.txt`) and uses regex to handle variations of the words. (`src/main/java/com/group/docorofile/utils/ProfanityFilter.java`)

* **Integrated profanity filtering in `MessageServiceImpl`**: Sanitizes the message content using `ProfanityFilter.filterBadWords` before saving it to the database. (`src/main/java/com/group/docorofile/services/impl/MessageServiceImpl.java`)

### Supporting Resources:
* **Added `badWords.txt` resource file**: Contains a list of banned words in multiple languages, which the `ProfanityFilter` uses to identify inappropriate content. (`src/main/resources/badWords.txt`)
![image](https://github.com/user-attachments/assets/5ce66068-c65b-4637-8aaf-334980e42c26)
