### PR TITLE
feature(payment): prevent Premium users from upgrading 

### DIFF
--- a/src/main/java/com/group/docorofile/configs/GlobalExceptionHandler.java
+++ b/src/main/java/com/group/docorofile/configs/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.group.docorofile.configs;
 
+import com.group.docorofile.exceptions.AlreadyPremiumException;
 import com.group.docorofile.exceptions.DocumentNotFoundException;
 import com.group.docorofile.exceptions.DuplicateReportException;
 import com.group.docorofile.exceptions.UserNotFoundException;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authorization.AuthorizationDeniedException;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
@@ -72,5 +74,12 @@ public class GlobalExceptionHandler {
         ErrorResponse error = new ErrorResponse(ex.getMessage(), HttpStatus.NOT_FOUND.value());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(error);
     }
+
+    @ExceptionHandler(AlreadyPremiumException.class)
+    public String handleAlreadyPremiumException(AlreadyPremiumException ex, Model model) {
+        model.addAttribute("message", ex.getMessage());
+        return "fragments/payment/error";
+    }
+
 
 }

--- a/src/main/java/com/group/docorofile/controllers/client/PaymentController.java
+++ b/src/main/java/com/group/docorofile/controllers/client/PaymentController.java
@@ -25,7 +25,12 @@ public class PaymentController {
 
     @PreAuthorize("hasAnyRole('ROLE_MEMBER')")
     @GetMapping("/pricing")
-    public String showPricingPage() {
+    public String showPricingPage(@CookieValue(value = "JWT", required = false) String token,
+                                  Model model) {
+
+        String membershipLevel = paymentService.getMembershipLevelFromToken(token);
+        model.addAttribute("membershipLevel", membershipLevel); // "FREE" or "PREMIUM"
+
         return "fragments/payment/pricing";
     }
 
@@ -58,15 +63,11 @@ public class PaymentController {
             model.addAttribute("status", "success");
         }
 
-        return "fragments/payment/payment_status"; // ❗ Trả thẳng view
+        return "fragments/payment/payment_status"; // Trả thẳng view
     }
 
 
-//    @GetMapping("/payment-status")
-//    public String paymentStatus(Model model, @RequestParam String status) {
-//        model.addAttribute("status", status);
-//        return "fragments/payment/payment_status";
-//    }
+
 }
 
 

--- a/src/main/java/com/group/docorofile/exceptions/AlreadyPremiumException.java
+++ b/src/main/java/com/group/docorofile/exceptions/AlreadyPremiumException.java
@@ -1,0 +1,7 @@
+package com.group.docorofile.exceptions;
+
+public class AlreadyPremiumException extends RuntimeException {
+    public AlreadyPremiumException(String message) {
+        super(message);
+    }
+}

--- a/src/main/resources/templates/fragments/payment/error.html
+++ b/src/main/resources/templates/fragments/payment/error.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.w3.org/1999/xhtml"
+      layout:decorate="~{layout}">
+<head>
+    <title>Tài khoản đã Premium</title>
+</head>
+<body>
+<div layout:fragment="content" class="container py-5">
+    <div class="alert alert-warning text-center">
+        <h3>🚫 Bạn đã là thành viên Premium</h3>
+        <p>Bạn không thể nâng cấp thêm nữa.</p>
+        <a href="/auth/login" class="btn btn-primary mt-3">Đăng nhập lại </a>
+    </div>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/fragments/payment/pricing.html
+++ b/src/main/resources/templates/fragments/payment/pricing.html
@@ -95,7 +95,7 @@
 
                                     <form action="/member/payment/vn-pay" method="post">
                                         <input type="hidden" name="amount" value="80000" />
-                                        <button type="submit" class="btn btn-outline-success d-grid w-100">Your Current Plan</button>
+                                        <button id="freePlanBtn" type="submit" class="btn btn-outline-success d-grid w-100">Your Current Plan</button>
                                     </form>
                                 </div>
                             </div>
@@ -131,7 +131,7 @@
 
                                     <form action="/member/payment/vn-pay" method="post">
                                         <input type="hidden" name="amount" value="80000" />
-                                        <button type="submit" class="btn btn-outline-primary d-grid w-100">Upgrade</button>
+                                        <button id="premiumPlanBtn" type="submit" class="btn btn-outline-primary d-grid w-100">Upgrade</button>
                                     </form>
 
                                 </div>
@@ -141,27 +141,60 @@
                 </div>
             </div>
             <!--/ Pricing Plans -->
+            <script th:inline="javascript">
+                const membershipLevel = /*[[${membershipLevel}]]*/ 'FREE';
+            </script>
+
+            <script>
+                document.addEventListener("DOMContentLoaded", function () {
+                    if (membershipLevel === 'PREMIUM') {
+                        // 1. Ẩn nút trong card FREE
+                        const freeButton = document.getElementById("freePlanBtn");
+                        if (freeButton) {
+                            freeButton.disabled = true;
+                            freeButton.classList.add('disabled'); // nếu bạn muốn thêm hiệu ứng mờ
+                            freeButton.textContent = 'Not Available';
+                            freeButton.classList.remove('btn-outline-success');
+                            freeButton.classList.add('btn-secondary');
+
+                        }
+
+                        // 2. Cập nhật nút trong card PREMIUM
+                        const premiumButton = document.getElementById("premiumPlanBtn");
+                        if (premiumButton) {
+                            premiumButton.textContent = 'Your Current Plan Here';
+                            premiumButton.classList.remove('btn-outline-primary');
+                            premiumButton.classList.add('btn-outline-success');
+                        }
+                    }
+                });
+            </script>
         </div>
+
+
     </div>
     <!-- / Content -->
+
 
     <div class="content-backdrop fade"></div>
 </div>
 <!-- Content wrapper -->
 <!-- Core JS -->
-<!-- build:js assets/vendor/js/core.js -->
-<script th:src="@{/assets/vendor/libs/jquery/jquery.js}"></script>
-<script th:src="@{/assets/vendor/libs/popper/popper.js}"></script>
-<script th:src="@{/assets/vendor/js/bootstrap.js}"></script>
-<script th:src="@{/assets/vendor/libs/node-waves/node-waves.js}"></script>
-<script th:src="@{/assets/vendor/libs/perfect-scrollbar/perfect-scrollbar.js}"></script>
-<script th:src="@{/assets/vendor/libs/hammer/hammer.js}"></script>
-<script th:src="@{/assets/vendor/libs/i18n/i18n.js}"></script>
-<script th:src="@{/assets/vendor/libs/typeahead-js/typeahead.js}"></script>
-<script th:src="@{/assets/vendor/js/menu.js}"></script>
+<!--&lt;!&ndash; build:js assets/vendor/js/core.js &ndash;&gt;-->
+<!--<script th:src="@{/assets/vendor/libs/jquery/jquery.js}"></script>-->
+<!--<script th:src="@{/assets/vendor/libs/popper/popper.js}"></script>-->
+<!--<script th:src="@{/assets/vendor/js/bootstrap.js}"></script>-->
+<!--<script th:src="@{/assets/vendor/libs/node-waves/node-waves.js}"></script>-->
+<!--<script th:src="@{/assets/vendor/libs/perfect-scrollbar/perfect-scrollbar.js}"></script>-->
+<!--<script th:src="@{/assets/vendor/libs/hammer/hammer.js}"></script>-->
+<!--<script th:src="@{/assets/vendor/libs/i18n/i18n.js}"></script>-->
+<!--<script th:src="@{/assets/vendor/libs/typeahead-js/typeahead.js}"></script>-->
+<!--<script th:src="@{/assets/vendor/js/menu.js}"></script>-->
 
 <!-- Main JS -->
 <script th:src="@{/assets/js/main.js}"></script>
+
+
 
 
 </body>


### PR DESCRIPTION
fix(payment): block Premium users from upgrading again and show custom error page
- Prevent Premium users from upgrading again by throwing AlreadyPremiumException.
- Add @ExceptionHandler to render a user-friendly error page instead of raw JSON.
- Create a dedicated error view at fragments/payment/error.html with a warning message and back button.
- Update the pricing page: if the user is already Premium, change the Upgrade button text to "Your Current Plan Here" and disable the Free plan button.


![image](https://github.com/user-attachments/assets/33ce16db-e3ef-40d1-beca-bf55453cd38f)

![image](https://github.com/user-attachments/assets/edbea4c9-89ba-4efb-841c-6c6a40e9784a)
