### PR TITLE
feature(manageReport): handle click to document page

### DIFF
--- a/src/main/java/com/group/docorofile/controllers/v1/api/report/ReportAPIController.java
+++ b/src/main/java/com/group/docorofile/controllers/v1/api/report/ReportAPIController.java
@@ -25,7 +25,7 @@ public class ReportAPIController {
         this.reportService = reportService;
     }
 
-    @PreAuthorize("hasAnyRole('ROLE_ADMIN', 'ROLE_MODERATOR', 'ROLE_MEMBER')")
+    @PreAuthorize("hasAnyRole('ROLE_MEMBER')")
     @PostMapping("/create")
     public ResponseEntity<SuccessResponse> createReport(@RequestBody CreateReportRequest reportRequest) {
         reportService.createReport(reportRequest);

--- a/src/main/resources/static/js/page_reports.js
+++ b/src/main/resources/static/js/page_reports.js
@@ -106,6 +106,10 @@ function showReportModal(documentId) {
             });
             $("#modalImage").attr("src", doc.data.coverImageUrl);
 
+            document.getElementById("viewDocBtn").addEventListener("click", function () {
+                window.location.href = `${window.location.origin}/documents/${documentId}`;
+            });
+
             $("#updateStatusBtn").off('click').on('click', function () {
                 const newStatus = $("#statusSelect").val();
                 $.ajax({

--- a/src/main/resources/templates/report/reports.html
+++ b/src/main/resources/templates/report/reports.html
@@ -12,7 +12,6 @@
 <body>
 <div class="container-fluid mt-4" layout:fragment="content">
     <h2 class="mb-4">Danh sách báo cáo</h2>
-
     <div class="card">
         <div class="card-datatable">
             <table class="table table-bordered">
@@ -58,6 +57,7 @@
                     <img id="modalImage"
                          style="width: 100%; border-radius: 6px;"
                          alt="Ảnh tài liệu" />
+                    <button id="viewDocBtn" class="btn btn-primary">Xem tài liệu</button>
                     <!-- Trạng thái -->
                     <div class="mb-3">
                         <label for="statusSelect" class="form-label">Trạng thái mới</label>


### PR DESCRIPTION
This pull request includes changes to adjust authorization for creating reports, add a new feature for viewing documents in the report modal, and make a minor UI adjustment in the reports page. Below is a summary of the most important changes:

### Authorization Changes:
* [`src/main/java/com/group/docorofile/controllers/v1/api/report/ReportAPIController.java`](diffhunk://#diff-b1935cd2cb5e0bee983b2443e63d7cd2994e3500828fb72fd2626fbe8f8722caL28-R28): Updated the `@PreAuthorize` annotation for the `createReport` endpoint to restrict access to users with the `ROLE_MEMBER` role only, removing `ROLE_ADMIN` and `ROLE_MODERATOR` from the allowed roles.

### New Document Viewing Feature:
* [`src/main/resources/static/js/page_reports.js`](diffhunk://#diff-89f77e24abb97ac6a867f13084d4ec3a31f5c8e441bcf59990ce3739146ae7fbR109-R112): Added an event listener to the "View Document" button in the report modal to redirect users to the document's page when clicked.
* [`src/main/resources/templates/report/reports.html`](diffhunk://#diff-87efb03f58e6a4aa92257d2bda30dc9ab209c4a4299ca4a7103a66f0ed2a7b36R60): Added a "View Document" button (`id="viewDocBtn"`) to the report modal for accessing the associated document.

### UI Adjustment:
* [`src/main/resources/templates/report/reports.html`](diffhunk://#diff-87efb03f58e6a4aa92257d2bda30dc9ab209c4a4299ca4a7103a66f0ed2a7b36L15): Removed an unnecessary blank line in the HTML structure of the reports page for better formatting.
![image](https://github.com/user-attachments/assets/ac610587-215c-4448-976d-d4a0956c91d5)
