### PR TITLE
feat(api): update API URLs to production server

### DIFF
--- a/src/main/java/com/group/docorofile/controllers/AuthController.java
+++ b/src/main/java/com/group/docorofile/controllers/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
         try {
             // Call REST API endpoint (API nội bộ)
             RestTemplate restTemplate = new RestTemplate();
-            String url = "http://localhost:9091/v1/api/auth/logout";
+            String url = "http://docorofile.phatit.id.vn/v1/api/auth/logout";
             ResponseEntity<Map> res = restTemplate.postForEntity(url, null, Map.class);
 
             Cookie cookie = new Cookie("JWT", null);
@@ -74,7 +74,7 @@ public class AuthController {
         try {
             // Call REST API endpoint (API nội bộ)
             RestTemplate restTemplate = new RestTemplate();
-            String url = "http://localhost:9091/v1/api/auth/login";
+            String url = "http://docorofile.phatit.id.vn/v1/api/auth/login";
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
@@ -107,7 +107,7 @@ public class AuthController {
     public String verifyEmail(@RequestParam("code") String code, @RequestParam("email") String email, Model model) {
         // Call REST API endpoint (API nội bộ)
         RestTemplate restTemplate = new RestTemplate();
-        String url = "http://localhost:9091/v1/api/auth/verify-email?code=" + code + "&email=" + email;
+        String url = "http://docorofile.phatit.id.vn/v1/api/auth/verify-email?code=" + code + "&email=" + email;
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -132,7 +132,7 @@ public class AuthController {
                                 Model model) {
         // Call REST API endpoint (API nội bộ)
         RestTemplate restTemplate = new RestTemplate();
-        String url = "http://localhost:9091/v1/api/auth/reset-password?code=" + code + "&email=" + email + "&newPassword=" + newPassword;
+        String url = "http://docorofile.phatit.id.vn/v1/api/auth/reset-password?code=" + code + "&email=" + email + "&newPassword=" + newPassword;
         HttpHeaders headers = new HttpHeaders();
 
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -165,7 +165,7 @@ public class AuthController {
         try {
             // Call REST API endpoint (API nội bộ)
             RestTemplate restTemplate = new RestTemplate();
-            String url = "http://localhost:9091/v1/api/users/newMember";
+            String url = "http://docorofile.phatit.id.vn/v1/api/users/newMember";
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
@@ -192,7 +192,7 @@ public class AuthController {
     public String loginGoogle(OAuth2AuthenticationToken oauth2Token, Model m, HttpServletResponse response) {
         try {
             RestTemplate restTemplate = new RestTemplate();
-            String url = "http://localhost:9091/v1/api/auth/login/oauth2";
+            String url = "http://docorofile.phatit.id.vn/v1/api/auth/login/oauth2";
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/group/docorofile/services/EmailService.java
+++ b/src/main/java/com/group/docorofile/services/EmailService.java
@@ -22,7 +22,7 @@ public class EmailService {
     private Map<String, String> emailTokenMap = new ConcurrentHashMap<>();
 
     public void sendVerificationEmail(String to, String verificationCode) throws MessagingException {
-        String url = "http://localhost:9091/auth/verify-email?code=" + verificationCode + "&email=" + to;
+        String url = "http://docorofile.phatit.id.vn/auth/verify-email?code=" + verificationCode + "&email=" + to;
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
         helper.setTo(to);
@@ -41,7 +41,7 @@ public class EmailService {
     }
 
     public void sendResetPasswordEmail(String to, String code, String password) throws MessagingException {
-        String url = "http://localhost:9091/auth/reset-password?code=" + code + "&email=" + to + "&newPassword=" + password;
+        String url = "http://docorofile.phatit.id.vn/auth/reset-password?code=" + code + "&email=" + to + "&newPassword=" + password;
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
         helper.setTo(to);

--- a/src/main/resources/static/js/app-chat.js
+++ b/src/main/resources/static/js/app-chat.js
@@ -6,7 +6,7 @@ let stompClient = null;
 let currentSubscription = null;
 
 function connectWebSocket() {
-  const socket = new SockJS("http://localhost:9091/ws");
+  const socket = new SockJS("http://docorofile.phatit.id.vn/ws");
   stompClient = Stomp.over(socket);
   stompClient.connect({}, () => {
     console.log("WebSocket connected");

--- a/src/main/resources/templates/fragments/auth/forgot-password.html
+++ b/src/main/resources/templates/fragments/auth/forgot-password.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{/fragments/auth/layout-auth}">
+      layout:decorate="~{fragments/auth/layout-auth}">
 <body>
 <div layout:fragment="content">
     <h4 class="mb-1">Forgot Password? 🔒</h4>

--- a/src/main/resources/templates/fragments/auth/login.html
+++ b/src/main/resources/templates/fragments/auth/login.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{/fragments/auth/layout-auth}">
+      layout:decorate="~{fragments/auth/layout-auth}">
 <body>
 <div layout:fragment="content">
     <h4 class="mb-1">Welcome back 👋</h4>

--- a/src/main/resources/templates/fragments/auth/register.html
+++ b/src/main/resources/templates/fragments/auth/register.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{/fragments/auth/layout-auth}">
+      layout:decorate="~{fragments/auth/layout-auth}">
 <body>
 <div layout:fragment="content">
     <h4 class="mb-1">Adventure starts here 🚀</h4>

--- a/src/main/resources/templates/fragments/auth/verify-email.html
+++ b/src/main/resources/templates/fragments/auth/verify-email.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-      layout:decorate="~{/fragments/auth/layout-auth}">
+      layout:decorate="~{fragments/auth/layout-auth}">
 <body>
 <div layout:fragment="content" class="card-body mt-1">
     <h4 class="mb-1">Verify your email ✉️</h4>


### PR DESCRIPTION
This pull request updates the base URLs for API endpoints and WebSocket connections to use the production domain, and fixes a minor issue in Thymeleaf template paths. Below is a breakdown of the most important changes:

### API Endpoint Updates
* Updated all REST API endpoint URLs in `AuthController.java` to use the production domain `http://docorofile.phatit.id.vn` instead of `http://localhost:9091`. This affects methods for login, logout, email verification, password reset, user registration, and OAuth2 login. [[1]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L56-R56) [[2]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L77-R77) [[3]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L110-R110) [[4]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L135-R135) [[5]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L168-R168) [[6]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L195-R195)
* Updated email service URLs in `EmailService.java` for verification and password reset emails to use the production domain. [[1]](diffhunk://#diff-05844c2b8326a1673ce6cb8ccdb54af113b3b43c3bcaa5839d9c2e6f749f6074L25-R25) [[2]](diffhunk://#diff-05844c2b8326a1673ce6cb8ccdb54af113b3b43c3bcaa5839d9c2e6f749f6074L44-R44)

### WebSocket Update
* Updated the WebSocket connection URL in `app-chat.js` to use the production domain `http://docorofile.phatit.id.vn`.

### Thymeleaf Template Fixes
* Fixed incorrect Thymeleaf `layout:decorate` paths in `forgot-password.html`, `login.html`, `register.html`, and `verify-email.html` by removing the leading slash (`/`) in the path. [[1]](diffhunk://#diff-c31699e7f6b0266094d5a2146fa3c6f5fd8a9b8d31fa0c699f5bed2b716b22ccL4-R4) [[2]](diffhunk://#diff-46cf69de3b868c814a85417b36a25fd70a7478d5ca2775ad0111f01c148010e9L4-R4) [[3]](diffhunk://#diff-d8b69996d1bc0cd7ea044c073b50541da054630301f3f3d2148b23930a5c9017L4-R4) [[4]](diffhunk://#diff-7ed746983fddb7003d5bbb2b8247672ef4d25d3aa84a2565bb130fab42cdf21eL4-R4)