### PR TITLE
feat(error-handling): improve error messages and enforce authentication for document downloads

### DIFF
--- a/src/main/java/com/group/docorofile/controllers/CustomErrorController.java
+++ b/src/main/java/com/group/docorofile/controllers/CustomErrorController.java
@@ -26,7 +26,7 @@ public class CustomErrorController implements ErrorController {
             case 404 -> "Trang không tồn tại";
             case 403 -> "Bạn không có quyền truy cập";
             case 401 -> "Vui lòng đăng nhập để tiếp tục";
-            default -> "Đã xảy ra lỗi không xác định: " + message.toString();
+            default -> "Đã xảy ra lỗi không xác định! ";
         };
         model.addAttribute("message", msg);
 

--- a/src/main/java/com/group/docorofile/controllers/v1/api/document/DocumentAPIController.java
+++ b/src/main/java/com/group/docorofile/controllers/v1/api/document/DocumentAPIController.java
@@ -296,25 +296,24 @@ public class DocumentAPIController {
                                        @RequestParam(defaultValue = "6") int size,
                                        @CookieValue(value = "JWT", required = false) String token)
     {
-        try {
-            String email = jwtTokenUtil.getUsernameFromToken(token);
-            Optional<UserEntity> optionalUser = userService.findByEmail(email);
-
-            if (optionalUser.isEmpty()) {
-                return new NotFoundError("Không tìm thấy người dùng với email: " + email);
-            }
-
-            UUID memberId = optionalUser.get().getUserId();
-            Page<UserDocumentDTO> historyDocuments = documentService.getHistoryDocumentsForUI(memberId, page, size);
-
-            if (historyDocuments.isEmpty()) {
-                return new NotFoundError("Không có tài liệu nào trong lịch sử xem!");
-            }
-
-            return new SuccessResponse("Lấy lịch sử xem tài liệu thành công!", 200, historyDocuments, LocalDateTime.now());
-        } catch (Exception e) {
-            return new InternalServerError(e.getMessage());
+        if (token == null || token.isEmpty()) {
+            return new UnauthorizedError("Bạn chưa đăng nhập!");
         }
+        String email = jwtTokenUtil.getUsernameFromToken(token);
+        Optional<UserEntity> optionalUser = userService.findByEmail(email);
+
+        if (optionalUser.isEmpty()) {
+            return new NotFoundError("Không tìm thấy người dùng với email: " + email);
+        }
+
+        UUID memberId = optionalUser.get().getUserId();
+        Page<UserDocumentDTO> historyDocuments = documentService.getHistoryDocumentsForUI(memberId, page, size);
+
+        if (historyDocuments.isEmpty()) {
+            return new NotFoundError("Không có tài liệu nào trong lịch sử xem!");
+        }
+
+        return new SuccessResponse("Lấy lịch sử xem tài liệu thành công!", 200, historyDocuments, LocalDateTime.now());
     }
 
     @GetMapping("/related/{documentId}")
@@ -322,15 +321,11 @@ public class DocumentAPIController {
             @PathVariable UUID documentId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "6") int size) {
-        try {
             Page<UserDocumentDTO> relatedDocuments = documentService.getRelatedDocumentsForUI(documentId, page, size);
             if (relatedDocuments.isEmpty()) {
                 return new NotFoundError("Không có tài liệu nào liên quan!");
             }
             return new SuccessResponse("Lấy danh sách tài liệu liên quan thành công!", 200, relatedDocuments, LocalDateTime.now());
-        } catch (RuntimeException e) {
-            return new InternalServerError(e.getMessage());
-        }
     }
 
     @PreAuthorize("hasRole('ROLE_MEMBER')")

--- a/src/main/java/com/group/docorofile/controllers/v1/api/document/DocumentAPIController.java
+++ b/src/main/java/com/group/docorofile/controllers/v1/api/document/DocumentAPIController.java
@@ -229,12 +229,15 @@ public class DocumentAPIController {
         }
     }
 
-    @GetMapping("/download/{documentId}")
     @PreAuthorize("hasRole('ROLE_MEMBER')")
+    @GetMapping("/download/{documentId}")
     public ResponseEntity<Resource> downloadDocument(@PathVariable UUID documentId,
                                                      @CookieValue(value = "JWT", required = false) String token) {
+        if (token == null || token.isEmpty()) {
+            throw new UnauthorizedError("Vui lòng đăng nhập!");
+        }
         UUID memberId = userService.findByEmail(jwtTokenUtil.getUsernameFromToken(token))
-                .orElseThrow(() -> new RuntimeException("Không tìm thấy người dùng"))
+                .orElseThrow(() -> new NotFoundError("Không tìm thấy người dùng"))
                 .getUserId();
         return documentService.downloadDocument(memberId, documentId);
     }

--- a/src/main/java/com/group/docorofile/services/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/group/docorofile/services/impl/DocumentServiceImpl.java
@@ -509,11 +509,11 @@ public class DocumentServiceImpl implements iDocumentService {
     public ResponseEntity<Resource> downloadDocument(UUID memberId, UUID documentId) {
         // Kiểm tra xem tài liệu có tồn tại không
         DocumentEntity document = documentRepository.findById(documentId)
-                .orElseThrow(() -> new RuntimeException("Tài liệu không tồn tại"));
+                .orElseThrow(() -> new NotFoundError("Tài liệu không tồn tại"));
 
         // Kiểm tra xem người dùng có tồn tại không
         MemberEntity member = (MemberEntity) userRepository.findById(memberId)
-                .orElseThrow(() -> new RuntimeException("Người dùng không tồn tại"));
+                .orElseThrow(() -> new NotFoundError("Người dùng không tồn tại"));
 
         // Nếu người dùng là Member thì kiểm tra số lượt tải
         if (member.getMembership().getLevel() == EMembershipLevel.FREE && member.getDownloadLimit() <= 0) {

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -579,6 +579,10 @@
                 credentials: "include"
             })
                 .then(async res => {
+                    if(res.url.includes("/error")) {
+                        window.location.href = res.url;
+                        return null;
+                    }
                     if (!res.ok) {
                         const contentType = res.headers.get("Content-Type");
 


### PR DESCRIPTION
This pull request focuses on improving error handling and user feedback in the application by replacing generic exceptions with more specific custom error types and refining error messages. The changes also enhance security checks for certain endpoints.

### Improvements to error handling:

* [`src/main/java/com/group/docorofile/controllers/CustomErrorController.java`](diffhunk://#diff-ab5b2c16e742efef5eb7946d3cbdc16f21fbf6492ce496b3afd044c4518f0cfaL29-R29): Simplified the default error message for unknown errors by removing the appended exception details.
* [`src/main/java/com/group/docorofile/services/impl/DocumentServiceImpl.java`](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bL512-R516): Replaced `RuntimeException` with `NotFoundError` for cases where documents or users are not found, providing more meaningful error feedback.

### Security enhancements:

* [`src/main/java/com/group/docorofile/controllers/v1/api/document/DocumentAPIController.java`](diffhunk://#diff-e0db4aa8a82f2e80fb73aa7061f881d9467730289a241f17dd7dd768cb45f0f3L232-R240): Added a check for the presence of a valid JWT token in the `downloadDocument` method and threw an `UnauthorizedError` if the token is missing, ensuring that only authenticated users can access the endpoint.