### PR TITLE
feat(document-repository): filter out deleted and draft documents in various retrieval methods

### DIFF
--- a/src/main/java/com/group/docorofile/repositories/DocumentRepository.java
+++ b/src/main/java/com/group/docorofile/repositories/DocumentRepository.java
@@ -15,7 +15,7 @@ import java.util.UUID;
 
 @Repository
 public interface DocumentRepository extends JpaRepository<DocumentEntity, UUID>, JpaSpecificationExecutor<DocumentEntity> {
-    @Query("SELECT COUNT(d) FROM DocumentEntity d WHERE DATE(d.uploadedDate) = :date AND d.author.userId = :memberId")
+    @Query("SELECT COUNT(d) FROM DocumentEntity d WHERE DATE(d.uploadedDate) = :date AND d.author.userId = :memberId AND d.status = 'PUBLIC'")
     int countDocumentUploadInDay (LocalDate date, UUID memberId);
 
     // Kiểm tra xem user đã tải lên tài liệu này chưa


### PR DESCRIPTION
This pull request introduces several changes to improve the filtering and handling of documents based on their status (`PUBLIC`, `DELETED`, and `DRAFT`). The changes ensure that only public documents are considered in searches, recommendations, and other operations, while deleted or draft documents are excluded. Additionally, the code has been updated to use the `EDocumentStatus` enum consistently. Below is a breakdown of the most important changes:

### Filtering Documents by Status

* Updated the query in `DocumentRepository` to include a condition that only counts documents with a `PUBLIC` status when checking daily uploads. (`[src/main/java/com/group/docorofile/repositories/DocumentRepository.javaL18-R18](diffhunk://#diff-f3cf05725e9617510cd6a0b26636eca43e47bb91225b487eede98e63b568ed51L18-R18)`)
* Added filters in multiple service methods to exclude documents with `DELETED` or `DRAFT` statuses, ensuring they are not returned in search results, recommendations, or history views. (`[[1]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bR149-R153)`, `[[2]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bL196-R202)`, `[[3]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bR233)`, `[[4]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bL271-R286)`, `[[5]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bR598-R600)`, `[[6]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bR624-R627)`, `[[7]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bL651-R699)`, `[[8]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bR709-R710)`)

### Consistency with `EDocumentStatus` Enum

* Replaced string comparisons (e.g., `"APPROVED"`) with the `EDocumentStatus` enum (e.g., `EDocumentStatus.PUBLIC`) for better type safety and maintainability. (`[[1]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bL196-R202)`, `[[2]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bR233)`, `[[3]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bL271-R286)`)

### Enhancements to Document Retrieval

* Modified methods like `getDocumentByCourseId` and `getDocumentByUniversityId` to explicitly remove `DELETED` and `DRAFT` documents from the results. (`[src/main/java/com/group/docorofile/services/impl/DocumentServiceImpl.javaL651-R699](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bL651-R699)`)
* Updated specifications for related and recommended documents to exclude `DELETED` and `DRAFT` statuses using criteria builders. (`[[1]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bR598-R600)`, `[[2]](diffhunk://#diff-80aa71cb9f792559f77e0d8ec4a0f11739b7b9079490c8137f38fd0db161085bR624-R627)`)

These changes improve the reliability and accuracy of document-related operations by ensuring that only valid and public documents are processed and displayed to users.