### PR TITLE
feat(document-repository): streamline document retrieval by removing unnecessary error handling and improving UI feedback

### DIFF
--- a/src/main/java/com/group/docorofile/controllers/v1/api/document/DocumentAPIController.java
+++ b/src/main/java/com/group/docorofile/controllers/v1/api/document/DocumentAPIController.java
@@ -333,25 +333,21 @@ public class DocumentAPIController {
     public Object getDocumentsByCourseFollowed (@RequestParam(defaultValue = "0") int page,
                                                 @RequestParam(defaultValue = "6") int size,
                                                 @CookieValue(value = "JWT", required = false) String token) {
-        try {
-            UUID memberId = userService.findByEmail(jwtTokenUtil.getUsernameFromToken(token)).get().getUserId();
-            if (memberId == null) {
-                return new UnauthorizedError("Bạn chưa đăng nhập!");
-            }
-            System.out.println("===================== " + memberId);
-            boolean courseFollowed = userService.courseFollowedByMember(memberId);
-
-            if (!courseFollowed) {
-                return new NotFoundError("Bạn chưa theo dõi khóa học nào!");
-            }
-            Page<UserDocumentDTO> documents = documentService.getDocumentByCourseAndFollowedByMemberForUI(memberId, page, size);
-            if (documents.isEmpty()) {
-                return new NotFoundError("Không có tài liệu nào trong khóa học đã theo dõi!");
-            }
-            return new SuccessResponse("Lấy danh sách tài liệu theo khóa học đã theo dõi thành công!", 200, documents, LocalDateTime.now());
-        } catch (RuntimeException e) {
-            return new InternalServerError(e.getMessage());
+        UUID memberId = userService.findByEmail(jwtTokenUtil.getUsernameFromToken(token)).get().getUserId();
+        if (memberId == null) {
+            return new UnauthorizedError("Bạn chưa đăng nhập!");
         }
+        System.out.println("===================== " + memberId);
+        boolean courseFollowed = userService.courseFollowedByMember(memberId);
+
+        if (!courseFollowed) {
+            return new NotFoundError("Bạn chưa theo dõi khóa học nào!");
+        }
+        Page<UserDocumentDTO> documents = documentService.getDocumentByCourseAndFollowedByMemberForUI(memberId, page, size);
+        if (documents.isEmpty()) {
+            return new NotFoundError("Không có tài liệu nào trong khóa học đã theo dõi!");
+        }
+        return new SuccessResponse("Lấy danh sách tài liệu theo khóa học đã theo dõi thành công!", 200, documents, LocalDateTime.now());
     }
 
     @PreAuthorize("hasRole('ROLE_MEMBER')")

--- a/src/main/java/com/group/docorofile/services/impl/DocumentServiceImpl.java
+++ b/src/main/java/com/group/docorofile/services/impl/DocumentServiceImpl.java
@@ -691,27 +691,17 @@ public class DocumentServiceImpl implements iDocumentService {
 
     @Override
     public Page<DocumentEntity> getDocumentByCourseAndFollowedByMember(UUID memberId, int page, int size) {
-        try {
-            List<UUID> courseIds = courseRepository.findFollowedCoursesByMemberId(memberId);
-            return documentRepository.findAll(DocumentSpecification.recommendDocuments(courseIds, null)
-                    .and((root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("status"), EDocumentStatus.DELETED)
-            ).and((root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("status"), EDocumentStatus.DRAFT)
-            ), PageRequest.of(page, size));
-        } catch (RuntimeException e) {
-            throw new InternalServerError(e.getMessage());
-        }
+        List<UUID> courseIds = courseRepository.findFollowedCoursesByMemberId(memberId);
+        return documentRepository.findAll(DocumentSpecification.recommendDocuments(courseIds, null)
+                .and((root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("status"), EDocumentStatus.DELETED)
+                ).and((root, query, criteriaBuilder) -> criteriaBuilder.notEqual(root.get("status"), EDocumentStatus.DRAFT)
+                ), PageRequest.of(page, size));
     }
 
     @Override
     public Page<UserDocumentDTO> getDocumentByCourseAndFollowedByMemberForUI(UUID memberId, int page, int size) {
-        try {
-            Page<DocumentEntity> documents = getDocumentByCourseAndFollowedByMember(memberId, page, size);
-            documents.getContent().removeIf(document -> document.getStatus() == EDocumentStatus.DELETED || document.getStatus() == EDocumentStatus.DRAFT);
-
-            return documents.map(DocumentMapper::toUserDTO);
-        } catch (RuntimeException e) {
-            throw new InternalServerError(e.getMessage());
-        }
+        Page<DocumentEntity> documents = getDocumentByCourseAndFollowedByMember(memberId, page, size);
+        return documents.map(DocumentMapper::toUserDTO);
     }
 
     @Override

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -263,8 +263,8 @@
             console.log('✅ Current User Info:', result.data);
 
             // Cập nhật thông tin người dùng vào UI
-            document.getElementById('fullName').innerText = result.data.name || 'Người dùng';
-            document.getElementById('membershipName').innerText = result.data.current_plan || 'Thành viên';
+            document.getElementById('fullName').innerText = result.data.name || 'Khách';
+            document.getElementById('membershipName').innerText = result.data.current_plan || 'GUEST';
             if (result.data.role === 'ROLE_MODERATOR') {
                 document.getElementById('membershipName').innerText = 'Moderator';
                 document.getElementById('membershipName').classList.add('text-danger');


### PR DESCRIPTION
This pull request focuses on improving error handling and updating UI text for better clarity and user experience. The most significant changes include removing redundant `try-catch` blocks from service and controller methods and updating fallback text for user information in the UI.

### Error Handling Improvements:
* Removed unnecessary `try-catch` blocks from `getDocumentsByCourseFollowed` in `DocumentAPIController`, simplifying the method and relying on global exception handling for better maintainability. [[1]](diffhunk://#diff-e0db4aa8a82f2e80fb73aa7061f881d9467730289a241f17dd7dd768cb45f0f3L336) [[2]](diffhunk://#diff-e0db4aa8a82f2e80fb73aa7061f881d9467730289a241f17dd7dd768cb45f0f3L352-L354)
* Removed redundant `try-catch` blocks in `getDocumentByCourseAndFollowedByMember` and `getDocumentByCourseAndFollowedByMemberForUI` in `DocumentServiceImpl`, streamlining the code and ensuring exceptions propagate appropriately.

### UI Updates:
* Updated fallback text in `layout.html` to display "Khách" (Guest) and "GUEST" instead of "Người dùng" (User) and "Thành viên" (Member) when user information is unavailable, improving clarity for unauthenticated users.