### PR TITLE
feat(api): update API endpoints to use local server URLs

### DIFF
--- a/src/main/java/com/group/docorofile/configs/OAuth2LoginConfig.java
+++ b/src/main/java/com/group/docorofile/configs/OAuth2LoginConfig.java
@@ -30,7 +30,7 @@ public class OAuth2LoginConfig {
                 .clientSecret(GOOGLE_CLIENT_SECRET)
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
-                .redirectUri("https://docorofile.phatit.id.vn/login/oauth2/code/{registrationId}")
+                .redirectUri("http://localhost:9091/login/oauth2/code/{registrationId}")
                 .scope("openid", "profile", "email", "address", "phone")
                 .authorizationUri("https://accounts.google.com/o/oauth2/v2/auth")
                 .tokenUri("https://www.googleapis.com/oauth2/v4/token")

--- a/src/main/java/com/group/docorofile/controllers/AuthController.java
+++ b/src/main/java/com/group/docorofile/controllers/AuthController.java
@@ -53,7 +53,7 @@ public class AuthController {
         try {
             // Call REST API endpoint (API nội bộ)
             RestTemplate restTemplate = new RestTemplate();
-            String url = "https://docorofile.phatit.id.vn/v1/api/auth/logout";
+            String url = "http://localhost:9091/v1/api/auth/logout";
             ResponseEntity<Map> res = restTemplate.postForEntity(url, null, Map.class);
 
             Cookie cookie = new Cookie("JWT", null);
@@ -74,7 +74,7 @@ public class AuthController {
         try {
             // Call REST API endpoint (API nội bộ)
             RestTemplate restTemplate = new RestTemplate();
-            String url = "https://docorofile.phatit.id.vn/v1/api/auth/login";
+            String url = "http://localhost:9091/v1/api/auth/login";
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
@@ -107,7 +107,7 @@ public class AuthController {
     public String verifyEmail(@RequestParam("code") String code, @RequestParam("email") String email, Model model) {
         // Call REST API endpoint (API nội bộ)
         RestTemplate restTemplate = new RestTemplate();
-        String url = "https://docorofile.phatit.id.vn/v1/api/auth/verify-email?code=" + code + "&email=" + email;
+        String url = "http://localhost:9091/v1/api/auth/verify-email?code=" + code + "&email=" + email;
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -132,7 +132,7 @@ public class AuthController {
                                 Model model) {
         // Call REST API endpoint (API nội bộ)
         RestTemplate restTemplate = new RestTemplate();
-        String url = "https://docorofile.phatit.id.vn/v1/api/auth/reset-password?code=" + code + "&email=" + email + "&newPassword=" + newPassword;
+        String url = "http://localhost:9091/v1/api/auth/reset-password?code=" + code + "&email=" + email + "&newPassword=" + newPassword;
         HttpHeaders headers = new HttpHeaders();
 
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -165,7 +165,7 @@ public class AuthController {
         try {
             // Call REST API endpoint (API nội bộ)
             RestTemplate restTemplate = new RestTemplate();
-            String url = "https://docorofile.phatit.id.vn/v1/api/users/newMember";
+            String url = "http://localhost:9091/v1/api/users/newMember";
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);
@@ -192,7 +192,7 @@ public class AuthController {
     public String loginGoogle(OAuth2AuthenticationToken oauth2Token, Model m, HttpServletResponse response) {
         try {
             RestTemplate restTemplate = new RestTemplate();
-            String url = "https://docorofile.phatit.id.vn/v1/api/auth/login/oauth2";
+            String url = "http://localhost:9091/v1/api/auth/login/oauth2";
 
             HttpHeaders headers = new HttpHeaders();
             headers.setContentType(MediaType.APPLICATION_JSON);

--- a/src/main/java/com/group/docorofile/services/EmailService.java
+++ b/src/main/java/com/group/docorofile/services/EmailService.java
@@ -22,7 +22,7 @@ public class EmailService {
     private Map<String, String> emailTokenMap = new ConcurrentHashMap<>();
 
     public void sendVerificationEmail(String to, String verificationCode) throws MessagingException {
-        String url = "https://docorofile.phatit.id.vn/auth/verify-email?code=" + verificationCode + "&email=" + to;
+        String url = "http://localhost:9091/auth/verify-email?code=" + verificationCode + "&email=" + to;
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
         helper.setTo(to);
@@ -41,7 +41,7 @@ public class EmailService {
     }
 
     public void sendResetPasswordEmail(String to, String code, String password) throws MessagingException {
-        String url = "https://docorofile.phatit.id.vn/auth/reset-password?code=" + code + "&email=" + to + "&newPassword=" + password;
+        String url = "http://localhost:9091/auth/reset-password?code=" + code + "&email=" + to + "&newPassword=" + password;
         MimeMessage mimeMessage = mailSender.createMimeMessage();
         MimeMessageHelper helper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
         helper.setTo(to);

--- a/src/main/resources/static/js/app-chat.js
+++ b/src/main/resources/static/js/app-chat.js
@@ -6,7 +6,7 @@ let stompClient = null;
 let currentSubscription = null;
 
 function connectWebSocket() {
-  const socket = new SockJS("https://docorofile.phatit.id.vn/ws");
+  const socket = new SockJS("http://localhost:9091/ws");
   stompClient = Stomp.over(socket);
   stompClient.connect({}, () => {
     console.log("WebSocket connected");


### PR DESCRIPTION
This pull request updates several URLs in the codebase to use the local development server (`http://localhost:9091`) instead of the production domain (`https://docorofile.phatit.id.vn`). This change allows for easier local testing and development by redirecting authentication, user management, email verification, password reset, and WebSocket endpoints to the local environment.

**Authentication and User Management (Controllers):**
* Updated all REST API endpoints in `AuthController.java` to use `http://localhost:9091` for login, logout, email verification, password reset, user registration, and Google OAuth2 login. [[1]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L56-R56) [[2]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L77-R77) [[3]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L110-R110) [[4]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L135-R135) [[5]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L168-R168) [[6]](diffhunk://#diff-e347615fac0d0a166144d36a4b774b5644d3ea9e32de4aa506d9e363fc7228c7L195-R195)

**OAuth2 Configuration:**
* Changed the Google OAuth2 redirect URI in `OAuth2LoginConfig.java` to point to the local server for authentication callbacks.

**Email Service:**
* Updated verification and password reset email links in `EmailService.java` to reference the local server. [[1]](diffhunk://#diff-05844c2b8326a1673ce6cb8ccdb54af113b3b43c3bcaa5839d9c2e6f749f6074L25-R25) [[2]](diffhunk://#diff-05844c2b8326a1673ce6cb8ccdb54af113b3b43c3bcaa5839d9c2e6f749f6074L44-R44)

**WebSocket Connection:**
* Modified the WebSocket endpoint in `app-chat.js` to connect to the local server.