### PR TITLE
DOC-1 TC80 fix(header, layout): update profile component visibility

### DIFF
--- a/src/main/resources/templates/fragments/shared/header.html
+++ b/src/main/resources/templates/fragments/shared/header.html
@@ -91,7 +91,7 @@
                     </div>
                 </a>
                 <ul class="dropdown-menu dropdown-menu-end">
-                    <li>
+                    <li id="profile-component">
                         <a class="dropdown-item" href="/member/profiles">
                             <div class="d-flex">
                                 <div class="flex-shrink-0 me-2">

--- a/src/main/resources/templates/layout.html
+++ b/src/main/resources/templates/layout.html
@@ -323,8 +323,9 @@
             console.error('❌ Lỗi khi lấy thông tin người dùng:', err);
 
             // Cập nhật thông tin người dùng vào UI
-            document.getElementById('fullName').innerText = 'Người dùng';
-            document.getElementById('membershipName').innerText = 'Thành viên';
+            document.getElementById('profile-component').classList.add('d-none');
+            // document.getElementById('fullName').innerText = 'Người dùng';
+            // document.getElementById('membershipName').innerText = 'Thành viên';
 
             // 👉 Hide protected dropdown items
             const protectedItems = [


### PR DESCRIPTION
This pull request introduces a small UI improvement related to user profile visibility in the dropdown menu. Specifically, the profile dropdown item is now hidden when user information fails to load, ensuring a cleaner interface in error scenarios.

* User Profile Dropdown Visibility:
  * Assigned an `id` (`profile-component`) to the profile dropdown item in `header.html` for easier DOM manipulation.
  * Updated the error handler in `layout.html` to hide the profile dropdown item (`profile-component`) when user information cannot be retrieved, rather than displaying placeholder text

<img width="289" height="174" alt="image" src="https://github.com/user-attachments/assets/222bcd8f-5941-43be-aee2-a76608eaf369" />
