### PR TITLE
Fix TC58

### DIFF
--- a/src/main/java/com/group/docorofile/repositories/ReportRepository.java
+++ b/src/main/java/com/group/docorofile/repositories/ReportRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -34,7 +35,6 @@ public interface ReportRepository extends JpaRepository<ReportEntity, UUID> {
 
     List<ReportEntity> findByReportedDoc_DocumentId(UUID documentId);
 
-    @Query("SELECT r.detail FROM ReportEntity r WHERE r.reportedDoc.documentId = :documentId ORDER BY r.createdOn DESC")
-    Page<String> findReportDetailsByDocumentId(UUID documentId, Pageable pageable);
-
+    @Query("SELECT r.detail, r.status FROM ReportEntity r WHERE r.reportedDoc.documentId = :documentId ORDER BY r.createdOn DESC")
+    Page<Object[]> findReportDetailsByDocumentId(@Param("documentId") UUID documentId, Pageable pageable);
 }

--- a/src/main/java/com/group/docorofile/services/impl/ReportServiceImpl.java
+++ b/src/main/java/com/group/docorofile/services/impl/ReportServiceImpl.java
@@ -24,8 +24,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 public class ReportServiceImpl implements iReportService {
@@ -101,17 +100,45 @@ public class ReportServiceImpl implements iReportService {
     }
 
     public ResultPaginationDTO getReportDetailsByDocumentId(UUID documentId, Pageable pageable) {
-        Page<String> pageResult = reportRepository.findReportDetailsByDocumentId(documentId, pageable);
+        Page<Object[]> pageResult = reportRepository.findReportDetailsByDocumentId(documentId, pageable);
 
+        // Tạo metadata cho phân trang
         ResultPaginationDTO.Meta meta = new ResultPaginationDTO.Meta();
         meta.setPage(pageResult.getNumber());
         meta.setPageSize(pageResult.getSize());
         meta.setPages(pageResult.getTotalPages());
         meta.setTotal(pageResult.getTotalElements());
 
+        List<String> details = pageResult.getContent().stream()
+                .map(row -> (String) row[0]) // cột 0 là detail
+                .toList();
+
+        List<String> statuses = pageResult.getContent().stream()
+                .map(row -> {
+                    if (row == null || row.length < 2 || row[1] == null) return null;
+                    Object s = row[1];
+                    if (s instanceof Enum<?>) {
+                        return ((Enum<?>) s).name();
+                    } else {
+                        return s.toString();
+                    }
+                })
+                .filter(Objects::nonNull)
+                .distinct() // tránh trùng lặp nếu có
+                .toList();
+
+        // Nếu có danh sách status thì lấy phần tử đầu tiên, nếu không thì null
+        String status = statuses.isEmpty() ? null : statuses.get(0);
+
+        // Gộp dữ liệu vào result
+        Map<String, Object> result = new HashMap<>();
+        result.put("details", details);
+        result.put("status", status);
+
+        // Trả về DTO
         ResultPaginationDTO resultPaginationDTO = new ResultPaginationDTO();
         resultPaginationDTO.setMeta(meta);
-        resultPaginationDTO.setResult(pageResult.getContent());
+        resultPaginationDTO.setResult(result);
 
         return resultPaginationDTO;
     }

--- a/src/main/resources/static/js/page_reports.js
+++ b/src/main/resources/static/js/page_reports.js
@@ -86,15 +86,25 @@ function showReportModal(documentId) {
         type: 'GET',
         dataType: 'json',
         success: function (doc) {
-            console.log("Doc", doc)
             // Gán dữ liệu vào modal
             $.ajax({
                 url: `/v1/api/reports/${documentId}?isHard=false`, // Gọi API lấy danh sách chi tiết
                 type: 'GET',
                 dataType: 'json',
                 success: function(response) {
-                    if (Array.isArray(response.result)) {
-                        const details = response.result; // Dữ liệu chi tiết từ response.result
+                    const currentStatus = response.result.status;
+
+                    // Nếu là DECLINED hoặc RESOLVED → khóa combobox
+                    if (currentStatus === "DECLINED" || currentStatus === "RESOLVED") {
+                        $("#statusSelect").prop("disabled", true);
+                        $("#updateStatusBtn").prop("disabled", true);
+                    }
+                    // Nếu là IN_PROGRESS → không cho quay về PENDING
+                    else if (currentStatus === "IN_PROGRESS") {
+                        $("#statusSelect").find('option[value="PENDING"]').prop("disabled", true);
+                    }
+                    if (Array.isArray(response.result.details)) {
+                        const details = response.result.details; // Dữ liệu chi tiết từ response.result
                         const detailListHtml = details.map(detail => `<li>${detail}</li>`).join('');
                         $("#detailList").html(detailListHtml); // Đưa danh sách chi tiết vào modal
                         renderPaginationControls(documentId, response.meta);
@@ -106,6 +116,7 @@ function showReportModal(documentId) {
                     showToast("Không thể tải chi tiết tài liệu", "danger");
                 }
             });
+
             $("#modalImage").attr("src", doc.data.coverImageUrl);
 
             document.getElementById("viewDocBtn").addEventListener("click", function () {
@@ -176,8 +187,6 @@ function showReportModal(documentId) {
             } else {
                 console.error("Modal element not found");
             }
-            // const modal = new bootstrap.Modal(document.getElementById('reportModal'));
-            // modal.show();
         },
         error: function (err) {
             showToast("Không thể tải chi tiết báo cáo", "danger")


### PR DESCRIPTION
This pull request enhances the report retrieval and display functionality by updating the backend to return both report details and their statuses, and by improving the frontend logic for handling report status and UI controls. The changes ensure that status information is consistently available and used to control user interactions in the report modal.

**Backend changes:**

* The `findReportDetailsByDocumentId` query in `ReportRepository` now returns both `detail` and `status` fields, and its method signature is updated to return a `Page<Object[]>` instead of just report details.
* The `getReportDetailsByDocumentId` method in `ReportServiceImpl` is updated to process the new query result, extracting both details and status, and returning them in a structured map as part of the `ResultPaginationDTO`.
* Added necessary import for `@Param` in `ReportRepository.java` and consolidated imports in `ReportServiceImpl.java`. [[1]](diffhunk://#diff-3794e52bc6bf0e44de9dc0c1681eda2a32e01b168b323f68b7e83bfeb779972cR9) [[2]](diffhunk://#diff-7234bd0aa6223a42e0c0d147345c89ff02bba09242f35b7c2dd74a90b6b3d57aL27-R27)

**Frontend changes:**
<img width="1909" height="908" alt="image" src="https://github.com/user-attachments/assets/d19e2e28-2ab4-49e4-8d91-bfcc8a90fe0b" />

* The `showReportModal` function in `page_reports.js` now reads the `status` from the API response and enables/disables UI controls (like the status combobox and update button) based on the current status. It also ensures the details are rendered from the updated response structure.
* Minor cleanup and removal of commented-out code in the modal display logic.
* Ensured modal image and event bindings are handled after AJAX calls.